### PR TITLE
Update bloc to current version in dart

### DIFF
--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -71,10 +71,10 @@ class CounterBloc extends Bloc<CounterEvent, number> {
   async *mapEventToState(event: CounterEvent) {
     switch (event) {
       case CounterEvent.increment:
-        yield this.currentState + 1
+        yield this.state + 1
         break
       case CounterEvent.decrement:
-        yield this.currentState - 1
+        yield this.state - 1
         break
     }
   }
@@ -97,13 +97,13 @@ Then we can dispatch events to our bloc like so:
 ```typescript
 const counterBloc = new CounterBloc()
 
-counterBloc.dispatch(CounterEvent.increment)
-counterBloc.dispatch(CounterEvent.increment)
-counterBloc.dispatch(CounterEvent.increment)
+counterBloc.add(CounterEvent.increment)
+counterBloc.add(CounterEvent.increment)
+counterBloc.add(CounterEvent.increment)
 
-counterBloc.dispatch(CounterEvent.decrement)
-counterBloc.dispatch(CounterEvent.decrement)
-counterBloc.dispatch(CounterEvent.decrement)
+counterBloc.add(CounterEvent.decrement)
+counterBloc.add(CounterEvent.decrement)
+counterBloc.add(CounterEvent.decrement)
 ```
 
 As our app grows and relies on multiple `Blocs`, it becomes useful to see the `Transitions` for all `Blocs`. This can easily be achieved by implementing a `BlocDelegate`.
@@ -122,13 +122,13 @@ Now that we have our `SimpleBlocDelegate`, we just need to tell the `BlocSupervi
 BlocSupervisor.delegate = new SimpleBlocDelegate()
 const counterBloc = new CounterBloc()
 
-counterBloc.dispatch(CounterEvent.increment) // { currentState: 0, event: CounterEvent.increment, nextState: 1 }
-counterBloc.dispatch(CounterEvent.increment) // { currentState: 1, event: CounterEvent.increment, nextState: 2 }
-counterBloc.dispatch(CounterEvent.increment) // { currentState: 2, event: CounterEvent.increment, nextState: 3 }
+counterBloc.add(CounterEvent.increment) // { currentState: 0, event: CounterEvent.increment, nextState: 1 }
+counterBloc.add(CounterEvent.increment) // { currentState: 1, event: CounterEvent.increment, nextState: 2 }
+counterBloc.add(CounterEvent.increment) // { currentState: 2, event: CounterEvent.increment, nextState: 3 }
 
-counterBloc.dispatch(CounterEvent.decrement) // { currentState: 3, event: CounterEvent.decrement, nextState: 2 }
-counterBloc.dispatch(CounterEvent.decrement) // { currentState: 2, event: CounterEvent.decrement, nextState: 1 }
-counterBloc.dispatch(CounterEvent.decrement) // { currentState: 1, event: CounterEvent.decrement, nextState: 0 }
+counterBloc.add(CounterEvent.decrement) // { currentState: 3, event: CounterEvent.decrement, nextState: 2 }
+counterBloc.add(CounterEvent.decrement) // { currentState: 2, event: CounterEvent.decrement, nextState: 1 }
+counterBloc.add(CounterEvent.decrement) // { currentState: 1, event: CounterEvent.decrement, nextState: 0 }
 ```
 
 At this point, all `Bloc` `Transitions` will be reported to the `SimpleBlocDelegate` and we can see them in the console after running our app.

--- a/packages/bloc/example/index.ts
+++ b/packages/bloc/example/index.ts
@@ -7,7 +7,7 @@ enum CounterEvent {
 
 class MyBlocDelegate extends BlocDelegate {
     onEvent(_: Bloc<any, any>, event: CounterEvent) {
-        console.log(`dispatched ${event}`);
+        console.log(`added ${event}`);
     }
 
     onTransition(_: Bloc<any, any>, transition: Transition<any, any>) {
@@ -28,11 +28,11 @@ class CounterBloc extends Bloc<CounterEvent, number> {
         switch (event) {
             case CounterEvent.increment:
                 await wait(1000); // Simulating Latency
-                yield this.currentState + 1;
+                yield this.state + 1;
                 break;
             case CounterEvent.decrement:
                 await wait(500); // Simulating Latency
-                yield this.currentState - 1;
+                yield this.state - 1;
                 break;
         }
     }
@@ -42,13 +42,13 @@ class CounterBloc extends Bloc<CounterEvent, number> {
     BlocSupervisor.delegate = new MyBlocDelegate();
     const counterBloc = new CounterBloc();
 
-    counterBloc.dispatch(CounterEvent.increment);
-    counterBloc.dispatch(CounterEvent.increment);
-    counterBloc.dispatch(CounterEvent.increment);
+    counterBloc.add(CounterEvent.increment);
+    counterBloc.add(CounterEvent.increment);
+    counterBloc.add(CounterEvent.increment);
 
-    counterBloc.dispatch(CounterEvent.decrement);
-    counterBloc.dispatch(CounterEvent.decrement);
-    counterBloc.dispatch(CounterEvent.decrement);
+    counterBloc.add(CounterEvent.decrement);
+    counterBloc.add(CounterEvent.decrement);
+    counterBloc.add(CounterEvent.decrement);
 })();
 
 async function wait(ms: number): Promise<void> {

--- a/packages/bloc/lib/src/bloc.ts
+++ b/packages/bloc/lib/src/bloc.ts
@@ -16,18 +16,16 @@ export abstract class Bloc<Event, State> extends Observable<State> {
     return this.stateSubject.value
   }
 
-  
-
-  listen(onData: (value: State) => void, onError?: ((onError: any) => any) | undefined, onDone?: (() => any) | undefined): Subscription {
-    return this.stateSubject.subscribe(
-      onData,
-      onError,
-      onDone,
-    )
+  listen(
+    onData: (value: State) => void,
+    onError?: ((onError: any) => any) | undefined,
+    onDone?: (() => any) | undefined
+  ): Subscription {
+    return this.stateSubject.subscribe(onData, onError, onDone)
   }
 
   constructor() {
-    super();
+    super()
     this.stateSubject = new BehaviorSubject(this.initialState())
     this.bindStateSubject()
   }

--- a/packages/bloc/lib/src/transition.ts
+++ b/packages/bloc/lib/src/transition.ts
@@ -1,3 +1,3 @@
 export class Transition<Event, State> {
-  constructor(public currentState: State, public event: Event, public nextState: State) {}
+  constructor(public state: State, public event: Event, public nextState: State) {}
 }

--- a/packages/bloc/package-lock.json
+++ b/packages/bloc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@felangel/bloc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/bloc/test/bloc.test.ts
+++ b/packages/bloc/test/bloc.test.ts
@@ -31,20 +31,20 @@ describe('CounterBloc', () => {
     expect(counterBloc.initialState()).toEqual(0)
   })
 
-  it('has correct currentState', () => {
-    expect(counterBloc.currentState).toEqual(0)
+  it('has correct state', () => {
+    expect(counterBloc.state).toEqual(0)
   })
 
-  it('has correct state stream before events are dispatched', async done => {
-    counterBloc.state.subscribe(state => {
+  it('has correct state stream before events are added', async done => {
+    counterBloc.listen(state => {
       expect(state).toEqual(0)
       done()
     })
   })
 
-  it('has correct state after a single event is dispatched', async done => {
+  it('has correct state after a single event is added', async done => {
     const emittedStates: number[] = []
-    counterBloc.state.subscribe(
+    counterBloc.listen(
       state => {
         emittedStates.push(state)
       },
@@ -60,15 +60,15 @@ describe('CounterBloc', () => {
         done()
       }
     )
-    counterBloc.dispatch(CounterEvent.increment)
+    counterBloc.add(CounterEvent.increment)
     setTimeout(() => {
       counterBloc.dispose()
     }, 0)
   })
 
-  it('has correct state after a multiple events are dispatched', async done => {
+  it('has correct state after a multiple events are added', async done => {
     const emittedStates: number[] = []
-    counterBloc.state.subscribe(
+    counterBloc.listen(
       state => {
         emittedStates.push(state)
       },
@@ -94,9 +94,9 @@ describe('CounterBloc', () => {
         done()
       }
     )
-    counterBloc.dispatch(CounterEvent.increment)
-    counterBloc.dispatch(CounterEvent.increment)
-    counterBloc.dispatch(CounterEvent.increment)
+    counterBloc.add(CounterEvent.increment)
+    counterBloc.add(CounterEvent.increment)
+    counterBloc.add(CounterEvent.increment)
     setTimeout(() => {
       counterBloc.dispose()
     }, 0)
@@ -104,7 +104,7 @@ describe('CounterBloc', () => {
 
   it('has correct state when mapEventToState yields the same state', async done => {
     const emittedStates: number[] = []
-    counterBloc.state.subscribe(
+    counterBloc.listen(
       state => {
         emittedStates.push(state)
       },
@@ -117,7 +117,7 @@ describe('CounterBloc', () => {
         done()
       }
     )
-    counterBloc.dispatch(CounterEvent.doNothing)
+    counterBloc.add(CounterEvent.doNothing)
     setTimeout(() => {
       counterBloc.dispose()
     }, 0)
@@ -126,7 +126,7 @@ describe('CounterBloc', () => {
   it('has correct state when transform used to filter distinct events', async done => {
     counterBloc = new DistinctCounterBloc()
     const emittedStates: number[] = []
-    counterBloc.state.subscribe(
+    counterBloc.listen(
       state => {
         emittedStates.push(state)
       },
@@ -142,8 +142,8 @@ describe('CounterBloc', () => {
         done()
       }
     )
-    counterBloc.dispatch(CounterEvent.increment)
-    counterBloc.dispatch(CounterEvent.increment)
+    counterBloc.add(CounterEvent.increment)
+    counterBloc.add(CounterEvent.increment)
     setTimeout(() => {
       counterBloc.dispose()
     }, 0)
@@ -152,7 +152,7 @@ describe('CounterBloc', () => {
   it('has correct state when transform used to switchMap events', async done => {
     counterBloc = new SwitchMapCounterBloc()
     const emittedStates: number[] = []
-    counterBloc.state.subscribe(
+    counterBloc.listen(
       state => {
         emittedStates.push(state)
       },
@@ -168,8 +168,8 @@ describe('CounterBloc', () => {
         done()
       }
     )
-    counterBloc.dispatch(CounterEvent.increment)
-    counterBloc.dispatch(CounterEvent.decrement)
+    counterBloc.add(CounterEvent.increment)
+    counterBloc.add(CounterEvent.decrement)
     setTimeout(() => {
       counterBloc.dispose()
     }, 0)
@@ -177,7 +177,7 @@ describe('CounterBloc', () => {
 
   it('has correct state when mapEventToState throws exception', async done => {
     const emittedStates: number[] = []
-    counterBloc.state.subscribe(
+    counterBloc.listen(
       state => {
         emittedStates.push(state)
       },
@@ -191,15 +191,15 @@ describe('CounterBloc', () => {
         done()
       }
     )
-    counterBloc.dispatch(CounterEvent.badEvent)
+    counterBloc.add(CounterEvent.badEvent)
     setTimeout(() => {
       counterBloc.dispose()
     }, 0)
   })
 
-  it('cannot dispatch after dispose called', () => {
+  it('cannot add after dispose called', () => {
     counterBloc.dispose()
-    counterBloc.dispatch(CounterEvent.increment)
+    counterBloc.add(CounterEvent.increment)
 
     expect(blocDelegate.onError).toBeCalledWith(counterBloc, new EventStreamClosedError())
     expect(blocDelegate.onError).toBeCalledTimes(1)

--- a/packages/bloc/test/test-helpers.ts
+++ b/packages/bloc/test/test-helpers.ts
@@ -19,13 +19,13 @@ export class CounterBloc extends Bloc<CounterEvent, number> {
   async *mapEventToState(event: CounterEvent) {
     switch (event) {
       case CounterEvent.increment:
-        yield this.currentState + 1
+        yield this.state + 1
         break
       case CounterEvent.decrement:
-        yield this.currentState - 1
+        yield this.state - 1
         break
       case CounterEvent.doNothing:
-        yield this.currentState
+        yield this.state
         break
       case CounterEvent.badEvent:
         throw new CounterBlocError()

--- a/packages/bloc/test/transition.test.ts
+++ b/packages/bloc/test/transition.test.ts
@@ -5,7 +5,7 @@ describe('Transition', () => {
   it('is instantiable', () => {
     const transition = new Transition<CounterEvent, number>(0, CounterEvent.increment, 1)
     expect(transition).toBeInstanceOf(Transition)
-    expect(transition.currentState).toEqual(0)
+    expect(transition.state).toEqual(0)
     expect(transition.event).toEqual(CounterEvent.increment)
     expect(transition.nextState).toEqual(1)
   })


### PR DESCRIPTION
Updated bloc to the latest API version:

- _bloc.state.listen -> bloc.listen_
- _bloc.currentState -> bloc.state_
- _dispatch deprecated in favor of add_

Decided to keep the dart API of listen instead of subscribe because..
- wanted to keep a familiar API between both javascript and dart versions
- It is a quick change
- If many developers request it later then it can be updated
- I assume developers using bloc.js are most likely going to be those who are coming from using the dart version
- I have a personal preference for listen over subscribe

Let me know what you think!

**Will update react-bloc in a following PR**