### PR TITLE
fix-tsconfig-generate-wrong-dist

### DIFF
--- a/packages/react-bloc/tsconfig.json
+++ b/packages/react-bloc/tsconfig.json
@@ -18,7 +18,6 @@
     ]
   },
   "include": [
-    "lib",
-    "test"
+    "lib"
   ]
 }


### PR DESCRIPTION
After `npm install @felangel/react-bloc`, I found out there is something wrong with the dist sturcture, so I think this should be fix as quick as possible to let package usable with other project 😄 

Before:
![image](https://user-images.githubusercontent.com/6420527/71156001-fed54b80-2279-11ea-8e9e-5db5b4401a6c.png)

After:
![image](https://user-images.githubusercontent.com/6420527/71156255-98046200-227a-11ea-86bf-048e16f4e03d.png)
