### PR TITLE
useBlocBuilder

### DIFF
--- a/packages/react-bloc/lib/src/hooks/use-bloc-builder.tsx
+++ b/packages/react-bloc/lib/src/hooks/use-bloc-builder.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Subscription } from "rxjs";
+
+interface BlocBuilderOptions {
+  condition: (previous: any, current: any) => boolean;
+}
+
+export default function useBlocBuilder(
+  bloc: any,
+  options?: BlocBuilderOptions
+) {
+  const [state, setState] = React.useState(bloc.state);
+  const mounted = React.useRef<any>(false);
+  const previousState = React.useRef<any>(null);
+  const subscription = React.useRef<any>(Subscription.EMPTY);
+  const thisBloc = React.useRef<any>(bloc);
+
+  const subscribe = () => {
+    subscription.current = thisBloc.current.listen((s: any) => {
+      let rebuild: boolean = options?.condition
+        ? options.condition.call(null, previousState.current, state)
+        : true;
+      if (rebuild) setState(s);
+      previousState.current = state;
+    });
+  };
+
+  const unsubscribe = () => {
+    subscription.current.unsubscribe();
+  };
+
+  React.useLayoutEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      subscribe();
+    } else {
+      unsubscribe();
+      thisBloc.current = bloc;
+      setState(bloc.state);
+      subscribe();
+    }
+    return () => unsubscribe();
+  });
+
+  return { state };
+}

--- a/packages/react-bloc/lib/src/hooks/use-bloc-builder.tsx
+++ b/packages/react-bloc/lib/src/hooks/use-bloc-builder.tsx
@@ -18,8 +18,9 @@ export default function useBlocBuilder(
   const subscribe = () => {
     subscription.current = thisBloc.current.listen((s: any) => {
       let rebuild: boolean = options?.condition
-        ? options.condition.call(null, previousState.current, state)
+        ? options.condition.call(null, state, s)
         : true;
+
       if (rebuild) setState(s);
       previousState.current = state;
     });
@@ -36,7 +37,6 @@ export default function useBlocBuilder(
     } else {
       unsubscribe();
       thisBloc.current = bloc;
-      setState(bloc.state);
       subscribe();
     }
     return () => unsubscribe();


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

useBlocBuilder hook. This is essentially a straight copy over of the BlocBuilder code but turned into a hook. The only differences between the two are:
- line 13, I needed a `mounted` variable for the `useEffect` so that subscribe is only called once on load
- line 21, I pass in `null` instead of `this`
- line 21, I pass in `state` and `s` instead of `previous` and `current`. I found that the rebuild was always one state cycle behind so I made this change
- line 36, I do **not** do a `if (bloc !== thisBloc.current)` check. I found that adding this check breaks the code
- line 38, I do **not** update `previousState` and I do not call `setState`. Doing so broke the code. 

I tested it pretty rigorously with `condition`, as well as yielding several states during one action - I think it should work well. Please let me know what you think! 

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
